### PR TITLE
remove Microsoft.net.http dependency

### DIFF
--- a/src/ReactiveDomain/ReactiveDomain/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain/ReactiveDomain/ReactiveDomain.nuspec
@@ -13,7 +13,6 @@
     <dependencies>
       <dependency id="EventStore.Client.Embedded" version="3.9.2" />
       <dependency id="log4net" version="2.0.7" />
-      <dependency id="Microsoft.Net.Http" version="2.2.29" />
       <dependency id="Microsoft.Tpl.DataFlow" version="4.5.24" />
       <dependency id="Nito.AsyncEx.Dataflow" version="3.0.0" />
       <dependency id="NLog" version="4.3.10" />


### PR DESCRIPTION
part of fix to remove all warnings

Bug 2562: ReactiveDomain.Tests nuget includes ReactiveDomain.dll instead of taking a dependency on it
http://hoprdsrc03:8080/tfs/Common%20Instrument%20Framework/Greylock/_workitems/edit/2562