### PR TITLE
Command builder refinement

### DIFF
--- a/src/ReactiveDomain/ReactiveDomain/ViewObjects/CommandBuilder.cs
+++ b/src/ReactiveDomain/ReactiveDomain/ViewObjects/CommandBuilder.cs
@@ -14,7 +14,7 @@ namespace ReactiveDomain.ViewObjects
     public static class CommandBuilder
     {
         /// <summary>
-        /// Creates a ReactiveCommand from an Action.
+        /// Creates a ReactiveCommand from an Action, with a defined CanExecute.
         /// </summary>
         /// <param name="canExecute"></param>
         /// <param name="action"></param>
@@ -31,7 +31,7 @@ namespace ReactiveDomain.ViewObjects
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand from an Action.
+        /// Creates a ReactiveCommand from an Action. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
         /// <param name="action"></param>
         /// <param name="scheduler"></param>
@@ -66,8 +66,7 @@ namespace ReactiveDomain.ViewObjects
         }
 
         /// <summary>
-        /// FromActionEx does the same thing as FromAction, except the action must be defined to take
-        /// an Object as input.
+        /// Creates a ReactiveCommand from an Action&lt;object&gt;, with a defined CanExecute.
         /// </summary>
         /// <param name="canExecute"></param>
         /// <param name="action"></param>
@@ -84,8 +83,7 @@ namespace ReactiveDomain.ViewObjects
         }
 
         /// <summary>
-        /// FromActionEx does the same thing as FromAction, except the action must be defined to take
-        /// an Object as input.
+        /// Creates a ReactiveCommand from an Action&lt;object&gt;. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
         /// <param name="action"></param>
         /// <param name="scheduler"></param>

--- a/src/ReactiveDomain/ReactiveDomain/ViewObjects/CommandBuilder.cs
+++ b/src/ReactiveDomain/ReactiveDomain/ViewObjects/CommandBuilder.cs
@@ -67,7 +67,7 @@ namespace ReactiveDomain.ViewObjects
 
         /// <summary>
         /// FromActionEx does the same thing as FromAction, except the action must be defined to take
-        /// an Object an input.
+        /// an Object as input.
         /// </summary>
         /// <param name="canExecute"></param>
         /// <param name="action"></param>
@@ -85,7 +85,7 @@ namespace ReactiveDomain.ViewObjects
 
         /// <summary>
         /// FromActionEx does the same thing as FromAction, except the action must be defined to take
-        /// an Object an input.
+        /// an Object as input.
         /// </summary>
         /// <param name="action"></param>
         /// <param name="scheduler"></param>


### PR DESCRIPTION
Use existing BuildFireCommand and BuildFireCommandEx to distinguish between commands that take inputs and those that don't. Do the same thing with FromAction (takes a parameterless `Action`) and FromActionEx (takes an `Action<object>`).

Rename BuildPublishCommand to BuildPublishEvent, since it expects a `Func<Event>` not a `Func<Command>`.

Add XML comments to all public methods.